### PR TITLE
♻️ Refactor: 일정 리스트 조회 Api 정렬기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,6 @@ out/
 src/main/resources/application.properties
 src/main/resources/application-local.properties
 src/main/resources/application.yml
+src/main/resources/application-local.yml
+src/main/resources/application-dev.yml
 log

--- a/src/main/java/com/ddd/oi/common/controller/EnumController.java
+++ b/src/main/java/com/ddd/oi/common/controller/EnumController.java
@@ -1,0 +1,45 @@
+package com.ddd.oi.common.controller;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ddd.oi.schedule.domain.enumType.GroupTag;
+import com.ddd.oi.schedule.domain.enumType.Mobility;
+import com.ddd.oi.schedule.domain.enumType.ScheduleTag;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/v1/enums")
+@Tag(name = "공통 ENUM", description = "모든 Enum 타입 값들을 조회합니다.")
+public class EnumController {
+
+	@GetMapping("/group-tags")
+	@Operation(summary = "GroupTag 목록 조회")
+	public List<String> getGroupTags() {
+		return Arrays.stream(GroupTag.values())
+			.map(Enum::name)
+			.toList();
+	}
+
+	@GetMapping("/mobility")
+	@Operation(summary = "Mobility 목록 조회")
+	public List<String> getMobilityTypes() {
+		return Arrays.stream(Mobility.values())
+			.map(Enum::name)
+			.toList();
+	}
+
+	@GetMapping("/schedule-tags")
+	@Operation(summary = "ScheduleTag 목록 조회")
+	public List<String> getScheduleTags() {
+		return Arrays.stream(ScheduleTag.values())
+			.map(Enum::name)
+			.toList();
+	}
+}

--- a/src/main/java/com/ddd/oi/common/controller/HealthController.java
+++ b/src/main/java/com/ddd/oi/common/controller/HealthController.java
@@ -1,0 +1,14 @@
+package com.ddd.oi.common.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/health")
+public class HealthController {
+	@GetMapping
+	public String healthCheck() {
+		return "OK";
+	}
+}

--- a/src/main/java/com/ddd/oi/contents/domain/Contents.java
+++ b/src/main/java/com/ddd/oi/contents/domain/Contents.java
@@ -1,6 +1,5 @@
 package com.ddd.oi.contents.domain;
 
-
 import com.ddd.oi.common.domain.BaseEntity;
 
 import jakarta.persistence.*;
@@ -9,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 @Entity
 @Table(name = "contents")
 @Getter
@@ -20,8 +20,7 @@ public class Contents extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "contents_id")
-	private Long contentsId;
+	private Long id;
 
 	@Column(name = "title", nullable = false)
 	private String title;

--- a/src/main/java/com/ddd/oi/schedule/domain/Schedule.java
+++ b/src/main/java/com/ddd/oi/schedule/domain/Schedule.java
@@ -1,10 +1,11 @@
 package com.ddd.oi.schedule.domain;
 
 import com.ddd.oi.common.domain.BaseEntity;
+import com.ddd.oi.schedule.domain.enumType.GroupTag;
+import com.ddd.oi.schedule.domain.enumType.Mobility;
+import com.ddd.oi.schedule.domain.enumType.ScheduleTag;
 import com.ddd.oi.user.domain.User;
 import jakarta.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,6 +13,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "schedule")
@@ -23,8 +26,7 @@ public class Schedule extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "schedule_id")
-	private Long scheduleId;
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
@@ -43,46 +45,27 @@ public class Schedule extends BaseEntity {
 	@Column(name = "mobility", nullable = false)
 	private Mobility mobility;
 
-	@Column(name = "first_group",nullable = false)
-	private String firstGroup;
-
-	@Column(name = "second_group")
-	private String secondGroup;
-
-	@Column(name = "third_group")
-	private String thirdGroup;
+	@ElementCollection(targetClass = GroupTag.class, fetch = FetchType.EAGER)
+	@CollectionTable(name = "schedule_group", joinColumns = @JoinColumn(name = "schedule_id"))
+	@Enumerated(EnumType.STRING)
+	@Column(name = "group_name", nullable = false)
+	private List<GroupTag> groups = new ArrayList<>();
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "schedule_tag", nullable = false)
 	private ScheduleTag scheduleTag;
 
-
-	public enum Mobility {
-		WALK, CAR, PUBLIC_TRANSPORT, BICYCLE
+	public void updateSchedule(String title, LocalDate startDate, LocalDate endDate, Mobility mobility,
+			List<GroupTag> groups) {
+		this.scheduleTitle = title;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.mobility = mobility;
+		this.groups = groups;
 	}
 
-	public enum ScheduleTag {
-		TRIP, DAILY,DATE, BUSINESS, OTHER
+	public List<GroupTag> getGroups() {
+		return this.groups;
 	}
-
-    public void updateSchedule(String title, LocalDate startDate, LocalDate endDate, Mobility mobility, List<String> groupList) {
-        this.scheduleTitle = title;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.mobility = mobility;
-        this.firstGroup = groupList.get(0);
-        this.secondGroup = groupList.size() > 1 ? groupList.get(1) : null;
-        this.thirdGroup = groupList.size() > 2 ? groupList.get(2) : null;
-    }
-
-
-    public List<String> getGroupList() {
-        List<String> result = new ArrayList<>();
-        result.add(firstGroup);
-        if (secondGroup != null) result.add(secondGroup);
-        if (thirdGroup != null) result.add(thirdGroup);
-        return result;
-    }
-
 
 }

--- a/src/main/java/com/ddd/oi/schedule/domain/enumType/GroupTag.java
+++ b/src/main/java/com/ddd/oi/schedule/domain/enumType/GroupTag.java
@@ -1,0 +1,14 @@
+package com.ddd.oi.schedule.domain.enumType;
+
+
+
+public enum GroupTag {
+	SOLO,
+	COUPLE,
+	FRIEND,
+	PARENTS,
+	SIBLINGS,
+	CHILDREN,
+	PET,
+	OTHER
+}

--- a/src/main/java/com/ddd/oi/schedule/domain/enumType/Mobility.java
+++ b/src/main/java/com/ddd/oi/schedule/domain/enumType/Mobility.java
@@ -1,0 +1,10 @@
+package com.ddd.oi.schedule.domain.enumType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public enum Mobility {
+    WALK,
+    CAR,
+    PUBLIC_TRANSPORT,
+    BICYCLE
+}

--- a/src/main/java/com/ddd/oi/schedule/domain/enumType/ScheduleTag.java
+++ b/src/main/java/com/ddd/oi/schedule/domain/enumType/ScheduleTag.java
@@ -1,0 +1,11 @@
+package com.ddd.oi.schedule.domain.enumType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public enum ScheduleTag {
+    TRIP,
+    DAILY,
+    DATE,
+    BUSINESS,
+    OTHER
+}

--- a/src/main/java/com/ddd/oi/schedule/dto/request/UpdateScheduleRequest.java
+++ b/src/main/java/com/ddd/oi/schedule/dto/request/UpdateScheduleRequest.java
@@ -2,32 +2,47 @@ package com.ddd.oi.schedule.dto.request;
 
 import com.ddd.oi.common.exception.OiException;
 import com.ddd.oi.common.response.ErrorCode;
-import com.ddd.oi.schedule.domain.Schedule.Mobility;
+import com.ddd.oi.schedule.domain.enumType.GroupTag;
+import com.ddd.oi.schedule.domain.enumType.Mobility;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record UpdateScheduleRequest(
-        String title,
-        LocalDate startDate,
-        LocalDate endDate,
-        Mobility mobility,
-        List<String> groupList
+        @Schema(description = "일정 제목", example = "여름휴가") String title,
 
+        @Schema(description = "시작 날짜", example = "2025-07-01") LocalDate startDate,
 
-) {
-    //TODO 커스텀 어노테이션을 빼는 방식 고민
+        @Schema(description = "종료 날짜", example = "2024-07-02") LocalDate endDate,
+
+        @Schema(description = "이동 수단", example = "CAR", allowableValues = {
+                "WALK", "CAR", "PUBLIC_TRANSPORT", "BICYCLE" }) Mobility mobility,
+
+        @Schema(description = "일행 태그 리스트", example = "[\"SOLO\", \"SIBLINGS\"]", allowableValues = { "SOLO", "COUPLE",
+                "FRIEND", "PARENTS", "SIBLINGS", "CHILDREN", "PET", "OTHER" }) List<String> groups){
     public UpdateScheduleRequest {
         if (startDate != null && endDate != null) {
             if (endDate.isBefore(startDate)) {
                 throw new OiException(ErrorCode.END_DATE_BEFORE_START_DATE);
             }
-            if (endDate.isAfter(startDate.plusDays(3))) {
+            if (startDate.plusDays(3).isBefore(endDate)) {
                 throw new OiException(ErrorCode.INVALID_DATE_RANGE);
             }
         }
-        if (groupList != null && groupList.size() != groupList.stream().distinct().count()) {
+        if (groups != null && groups.size() != groups.stream().distinct().count()) {
             throw new OiException(ErrorCode.DUPLICATE_GROUP_NAME);
         }
     }
 
+    public List<GroupTag> toGroupsEnum() {
+        if (this.groups == null) {
+            return null;
+        }
+        return this.groups.stream()
+                .map(String::toUpperCase)
+                .map(GroupTag::valueOf)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/ddd/oi/schedule/dto/response/CreateScheduleResponse.java
+++ b/src/main/java/com/ddd/oi/schedule/dto/response/CreateScheduleResponse.java
@@ -1,14 +1,16 @@
 package com.ddd.oi.schedule.dto.response;
 
-import lombok.Builder;
+import lombok.Getter;
 
-@Builder
-public record CreateScheduleResponse(
-        Long scheduleId
-) {
-    public static CreateScheduleResponse of(Long scheduleId) {
-        return CreateScheduleResponse.builder()
-                .scheduleId(scheduleId)
-                .build();
+@Getter
+public class CreateScheduleResponse {
+    private Long id;
+
+    private CreateScheduleResponse(Long id) {
+        this.id = id;
+    }
+
+    public static CreateScheduleResponse of(Long id) {
+        return new CreateScheduleResponse(id);
     }
 }

--- a/src/main/java/com/ddd/oi/schedule/dto/response/ScheduleListResponse.java
+++ b/src/main/java/com/ddd/oi/schedule/dto/response/ScheduleListResponse.java
@@ -1,9 +1,12 @@
 package com.ddd.oi.schedule.dto.response;
 
 import com.ddd.oi.schedule.domain.Schedule;
-import com.ddd.oi.schedule.domain.Schedule.Mobility;
-import com.ddd.oi.schedule.domain.Schedule.ScheduleTag;
+import com.ddd.oi.schedule.domain.enumType.GroupTag;
+import com.ddd.oi.schedule.domain.enumType.Mobility;
+import com.ddd.oi.schedule.domain.enumType.ScheduleTag;
 import java.time.LocalDate;
+import java.util.List;
+
 import lombok.Builder;
 
 @Builder
@@ -13,16 +16,17 @@ public record ScheduleListResponse(
         String title,
         LocalDate startDate,
         LocalDate endDate,
-        Mobility mobility
-) {
+        Mobility mobility,
+        List<GroupTag> groups) {
     public static ScheduleListResponse of(Schedule schedule) {
         return ScheduleListResponse.builder()
-                .scheduleId(schedule.getScheduleId())
+                .scheduleId(schedule.getId())
                 .scheduleTag(schedule.getScheduleTag())
                 .title(schedule.getScheduleTitle())
                 .startDate(schedule.getStartDate())
                 .endDate(schedule.getEndDate())
                 .mobility(schedule.getMobility())
+                .groups(schedule.getGroups())
                 .build();
     }
 }

--- a/src/main/java/com/ddd/oi/schedule/dto/response/UpdateScheduleResponse.java
+++ b/src/main/java/com/ddd/oi/schedule/dto/response/UpdateScheduleResponse.java
@@ -1,28 +1,32 @@
 package com.ddd.oi.schedule.dto.response;
 
 import com.ddd.oi.schedule.domain.Schedule;
-import com.ddd.oi.schedule.domain.Schedule.Mobility;
+import com.ddd.oi.schedule.domain.enumType.Mobility;
+import com.ddd.oi.schedule.domain.enumType.ScheduleTag;
+
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Builder;
 
 @Builder
 public record UpdateScheduleResponse(
-        Long scheduleId,
+        Long id,
         String title,
         LocalDate startDate,
         LocalDate endDate,
         Mobility mobility,
-        List<String> groupList
-) {
+        List<String> groups,
+        ScheduleTag scheduleTag) {
     public static UpdateScheduleResponse of(Schedule schedule) {
         return UpdateScheduleResponse.builder()
-                .scheduleId(schedule.getScheduleId())
+                .id(schedule.getId())
                 .title(schedule.getScheduleTitle())
                 .startDate(schedule.getStartDate())
                 .endDate(schedule.getEndDate())
                 .mobility(schedule.getMobility())
-                .groupList(schedule.getGroupList())
+                .groups(schedule.getGroups().stream().map(Enum::name).collect(Collectors.toList()))
+                .scheduleTag(schedule.getScheduleTag())
                 .build();
     }
 }

--- a/src/main/java/com/ddd/oi/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/ddd/oi/schedule/repository/ScheduleRepository.java
@@ -9,22 +9,30 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
-    Optional<Schedule> findByUser_UserIdAndScheduleId(Long userId, Long scheduleId);
-    @Query("SELECT s FROM Schedule s WHERE s.user.userId = :userId AND s.startDate <= :targetDay AND s.endDate >= :targetDay")
-    List<Schedule> findSchedulesByUserIdAndTargetDay(@Param("userId") Long userId, @Param("targetDay") LocalDate targetDay);
-    @Query("SELECT s FROM Schedule s WHERE s.user.userId = :userId AND " +
-            "((YEAR(s.startDate) = :year AND MONTH(s.startDate) = :month) OR " +
-            "(YEAR(s.endDate) = :year AND MONTH(s.endDate) = :month) OR " +
-            "(s.startDate <= :endOfMonth AND s.endDate >= :startOfMonth))")
-    List<Schedule> findSchedulesByUserIdAndMonth(
+        Optional<Schedule> findByUser_IdAndId(Long userId, Long scheduleId);
+
+        @Query("SELECT s FROM Schedule s " +
+            "WHERE s.user.id = :userId " +
+            "AND :targetDay BETWEEN s.startDate AND s.endDate " +
+            "ORDER BY s.startDate")
+        List<Schedule> findSchedulesByUserIdAndTargetDay(
+            @Param("userId") Long userId,
+            @Param("targetDay") LocalDate targetDay);
+
+        @Query("SELECT s FROM Schedule s " +
+            "WHERE s.user.id = :userId " +
+            "AND ((YEAR(s.startDate) = :year AND MONTH(s.startDate) = :month) " +
+            "   OR (YEAR(s.endDate) = :year AND MONTH(s.endDate) = :month) " +
+            "   OR (s.startDate <= :endOfMonth AND s.endDate >= :startOfMonth)) " +
+            "ORDER BY s.startDate")
+        List<Schedule> findSchedulesByUserIdAndMonth(
             @Param("userId") Long userId,
             @Param("year") int year,
             @Param("month") int month,
             @Param("startOfMonth") LocalDate startOfMonth,
-            @Param("endOfMonth") LocalDate endOfMonth
-    );
+            @Param("endOfMonth") LocalDate endOfMonth);
+
 
 }

--- a/src/main/java/com/ddd/oi/schedule/service/ScheduleService.java
+++ b/src/main/java/com/ddd/oi/schedule/service/ScheduleService.java
@@ -21,80 +21,78 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ScheduleService {
 
-    private final ScheduleRepository scheduleRepository;
-    private final UserRepository userRepository;
+        private final ScheduleRepository scheduleRepository;
+        private final UserRepository userRepository;
 
-    @Transactional
-    public CreateScheduleResponse createSchedule(Long userId, CreateScheduleRequest request) {
-         User user = userRepository.findById(userId)
-                 .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
-
-             Schedule newSchedule = request.toEntity(user);
-
-             scheduleRepository.save(newSchedule);
-
-             return CreateScheduleResponse.of(newSchedule.getScheduleId());
-         }
-
-    @Transactional
-    public void deleteSchedule (Long userId, Long scheduleId){
-           User user = userRepository.findById(userId)
-                     .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
-
-           Schedule schedule = scheduleRepository.findByUser_UserIdAndScheduleId(userId,
-                             scheduleId)
-                     .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
-
-             scheduleRepository.delete(schedule);
-
-         }
-
-    @Transactional
-    public UpdateScheduleResponse updateSchedule (Long userId, Long
-         scheduleId, UpdateScheduleRequest request){
-             User user = userRepository.findById(userId)
-                     .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
-
-             Schedule schedule = scheduleRepository.findByUser_UserIdAndScheduleId(userId,
-                             scheduleId)
-                     .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
-
-             schedule.updateSchedule(
-                     request.title(),
-                     request.startDate(),
-                     request.endDate(),
-                     request.mobility(),
-                     request.groupList()
-             );
-
-             return UpdateScheduleResponse.of(schedule);
-         }
-
-    @Transactional(readOnly = true)
-    public List<ScheduleListResponse> showTargetDaySchedule(Long userId,LocalDate targetDay) {
+        @Transactional
+        public CreateScheduleResponse createSchedule(Long userId, CreateScheduleRequest request) {
                 User user = userRepository.findById(userId)
-                        .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+                                .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
 
-             List<Schedule> schedules = scheduleRepository.findSchedulesByUserIdAndTargetDay(user.getUserId(), targetDay);
-             return schedules.stream()
-                     .map(ScheduleListResponse::of)
-                     .toList();
-     }
+                Schedule newSchedule = request.toEntity(user);
 
-    @Transactional(readOnly = true)
-    public List<ScheduleListResponse> showMonthScheduleList(Long userId, int year, int month) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+                scheduleRepository.save(newSchedule);
 
-        LocalDate startOfMonth = LocalDate.of(year, month, 1);
-        LocalDate endOfMonth = startOfMonth.withDayOfMonth(startOfMonth.lengthOfMonth());
+                return CreateScheduleResponse.of(newSchedule.getId());
+        }
 
-        List<Schedule> schedules = scheduleRepository.findSchedulesByUserIdAndMonth(
-                userId, year, month, startOfMonth, endOfMonth);
+        @Transactional
+        public void deleteSchedule(Long userId, Long scheduleId) {
+                User user = userRepository.findById(userId)
+                                .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
 
-        return schedules.stream()
-                .map(ScheduleListResponse::of)
-                .toList();
-    }
+                Schedule schedule = scheduleRepository.findByUser_IdAndId(userId,
+                                scheduleId)
+                                .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+
+                scheduleRepository.delete(schedule);
+        }
+
+        @Transactional
+        public UpdateScheduleResponse updateSchedule(Long userId, Long scheduleId, UpdateScheduleRequest request) {
+                User user = userRepository.findById(userId)
+                                .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+
+                Schedule schedule = scheduleRepository.findByUser_IdAndId(userId,
+                                scheduleId)
+                                .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+
+                schedule.updateSchedule(
+                                request.title(),
+                                request.startDate(),
+                                request.endDate(),
+                                request.mobility(),
+                                request.toGroupsEnum());
+
+                return UpdateScheduleResponse.of(schedule);
+        }
+
+        @Transactional(readOnly = true)
+        public List<ScheduleListResponse> showTargetDaySchedule(Long userId, LocalDate targetDay) {
+                User user = userRepository.findById(userId)
+                                .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+
+                List<Schedule> schedules = scheduleRepository.findSchedulesByUserIdAndTargetDay(user.getId(),
+                                targetDay);
+                return schedules.stream()
+                                .map(ScheduleListResponse::of)
+                                .toList();
+        }
+
+        @Transactional(readOnly = true)
+        public List<ScheduleListResponse> showMonthScheduleList(Long userId, int year, int month) {
+                User user = userRepository.findById(userId)
+                                .orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+
+                LocalDate startOfMonth = LocalDate.of(year, month, 1);
+                LocalDate endOfMonth = startOfMonth.withDayOfMonth(startOfMonth.lengthOfMonth());
+
+                List<Schedule> schedules = scheduleRepository.findSchedulesByUserIdAndMonth(
+                                userId, year, month, startOfMonth, endOfMonth);
+
+                return schedules.stream()
+                                .map(ScheduleListResponse::of)
+                                .toList();
+        }
 
 }

--- a/src/main/java/com/ddd/oi/schedule_detail/domain/ScheduleDetail.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/domain/ScheduleDetail.java
@@ -26,8 +26,7 @@ public class ScheduleDetail extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "schedule_detail_id")
-	private Long scheduleDetailId;
+	private Long id;
 
 	@Column(name = "start_time", nullable = false)
 	@Schema(type = "string", format = "time", pattern = "HH:mm", example = "14:30")
@@ -52,7 +51,6 @@ public class ScheduleDetail extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "schedule_id", nullable = false)
 	private Schedule schedule;
-
 
 	public void update(LocalTime startTime, String memo, String spotName, Double latitude, Double longitude) {
 		this.startTime = startTime;

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/request/CreateDetailRequest.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/request/CreateDetailRequest.java
@@ -9,22 +9,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateDetailRequest(
-	@NotNull
-	@JsonFormat(pattern = "HH:mm")
-	@Schema(type = "string", format = "time", pattern = "HH:mm", example = "14:30")
-	LocalTime startTime,
+		@NotNull @JsonFormat(pattern = "HH:mm") @Schema(type = "string", format = "time", pattern = "HH:mm", example = "14:30", description = "시작 시간") LocalTime startTime,
 
-	String memo,
-	@NotNull
-	LocalDate targetDate,
+		@Schema(description = "메모", example = "아침 식사 후 출발") String memo,
 
-	@NotNull
-	String spotName,
+		@NotNull @Schema(description = "날짜", example = "2025-07-01") LocalDate targetDate,
 
-	@NotNull
-	Double latitude,
+		@NotNull @Schema(description = "장소명", example = "서울역") String spotName,
 
-	@NotNull
-	Double longitude
-) {
+		@NotNull @Schema(description = "위도", example = "37.554722") Double latitude,
+
+		@NotNull @Schema(description = "경도", example = "126.970833") Double longitude) {
 }

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/request/UpdateDetailRequest.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/request/UpdateDetailRequest.java
@@ -1,26 +1,21 @@
 package com.ddd.oi.schedule_detail.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record UpdateDetailRequest(
-	@NotNull
-	@JsonFormat(pattern = "HH:mm")
-	LocalTime startTime,
+		@NotNull @JsonFormat(pattern = "HH:mm") @Schema(type = "string", format = "time", pattern = "HH:mm", example = "14:30", description = "시작 시간") LocalTime startTime,
 
-	@NotNull
-	LocalDate targetDate,
+		@NotNull @Schema(description = "날짜", example = "2025-07-01") LocalDate targetDate,
 
-	String memo,
+		@Schema(description = "메모", example = "아침 식사 후 출발") String memo,
 
-	@NotNull
-	String spotName,
+		@NotNull @Schema(description = "장소명", example = "서울역") String spotName,
 
-	@NotNull
-	Double latitude,
+		@NotNull @Schema(description = "위도", example = "37.554722") Double latitude,
 
-	@NotNull
-	Double longitude
-) {}
+		@NotNull @Schema(description = "경도", example = "126.970833") Double longitude) {
+}

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/response/ScheduleDetailResponse.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/response/ScheduleDetailResponse.java
@@ -11,23 +11,19 @@ import lombok.Builder;
 
 @Builder
 public record ScheduleDetailResponse(
-	Long detailId,
-	@JsonFormat(pattern = "HH:mm")
-	LocalTime startTime,
-	String memo,
-	LocalDate targetDate,
-	String spotName,
-	Double latitude,
-	Double longitude) {
+		Long id,
+		@JsonFormat(pattern = "HH:mm") LocalTime startTime,
+		String spotName,
+		Double latitude,
+		Double longitude,
+		String memo) {
 	public static ScheduleDetailResponse from(ScheduleDetail entity) {
 		return new ScheduleDetailResponse(
-			entity.getScheduleDetailId(),
-			entity.getStartTime(),
-			entity.getMemo(),
-			entity.getTargetDate(),
-			entity.getSpotName(),
-			entity.getLatitude(),
-			entity.getLongitude()
-		);
+				entity.getId(),
+				entity.getStartTime(),
+				entity.getSpotName(),
+				entity.getLatitude(),
+				entity.getLongitude(),
+				entity.getMemo());
 	}
 }

--- a/src/main/java/com/ddd/oi/schedule_detail/repository/ScheduleDetailRepository.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/repository/ScheduleDetailRepository.java
@@ -1,6 +1,7 @@
 package com.ddd.oi.schedule_detail.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -9,8 +10,9 @@ import java.util.Optional;
 
 import com.ddd.oi.schedule_detail.domain.ScheduleDetail;
 
+@Repository
 public interface ScheduleDetailRepository extends JpaRepository<ScheduleDetail, Long> {
-	List<ScheduleDetail> findBySchedule_ScheduleIdAndTargetDate(Long scheduleId, LocalDate targetDate);
-	Optional<ScheduleDetail> findByScheduleDetailIdAndSchedule_ScheduleId(Long detailId, Long scheduleId);
-}
+	List<ScheduleDetail> findBySchedule_IdAndTargetDate(Long scheduleId, LocalDate targetDate);
 
+	Optional<ScheduleDetail> findByIdAndSchedule_Id(Long scheduleDetailId, Long scheduleId);
+}

--- a/src/main/java/com/ddd/oi/schedule_detail/service/ScheduleDetailService.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/service/ScheduleDetailService.java
@@ -28,28 +28,28 @@ public class ScheduleDetailService {
 	@Transactional(readOnly = true)
 	public List<ScheduleDetailResponse> getDetails(Long scheduleId, LocalDate targetDate) {
 		Schedule schedule = scheduleRepository.findById(scheduleId)
-			.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+				.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
 
-		return scheduleDetailRepository.findBySchedule_ScheduleIdAndTargetDate(scheduleId, targetDate)
-			.stream()
-			.map(ScheduleDetailResponse::from)
-			.toList();
+		return scheduleDetailRepository.findBySchedule_IdAndTargetDate(scheduleId, targetDate)
+				.stream()
+				.map(ScheduleDetailResponse::from)
+				.toList();
 	}
 
 	@Transactional
 	public void createDetail(Long scheduleId, CreateDetailRequest request) {
 		Schedule schedule = scheduleRepository.findById(scheduleId)
-			.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+				.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
 
 		ScheduleDetail detail = ScheduleDetail.builder()
-			.schedule(schedule)
-			.startTime(request.startTime())
-			.targetDate(request.targetDate())
-			.memo(request.memo())
-			.spotName(request.spotName())
-			.latitude(request.latitude())
-			.longitude(request.longitude())
-			.build();
+				.schedule(schedule)
+				.startTime(request.startTime())
+				.targetDate(request.targetDate())
+				.memo(request.memo())
+				.spotName(request.spotName())
+				.latitude(request.latitude())
+				.longitude(request.longitude())
+				.build();
 
 		ScheduleDetail saved = scheduleDetailRepository.save(detail);
 	}
@@ -57,24 +57,23 @@ public class ScheduleDetailService {
 	@Transactional
 	public void updateDetail(Long scheduleId, Long detailId, UpdateDetailRequest request) {
 		Schedule schedule = scheduleRepository.findById(scheduleId)
-			.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+				.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
 
-		ScheduleDetail detail = scheduleDetailRepository.findByScheduleDetailIdAndSchedule_ScheduleId(detailId, scheduleId)
-			.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+		ScheduleDetail detail = scheduleDetailRepository.findByIdAndSchedule_Id(detailId, scheduleId)
+				.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
 
 		detail.update(
-			request.startTime(),
-			request.memo(),
-			request.spotName(),
-			request.latitude(),
-			request.longitude()
-		);
+				request.startTime(),
+				request.memo(),
+				request.spotName(),
+				request.latitude(),
+				request.longitude());
 	}
 
 	@Transactional
 	public void deleteDetail(Long scheduleId, Long detailId) {
-		ScheduleDetail detail = scheduleDetailRepository.findByScheduleDetailIdAndSchedule_ScheduleId(detailId, scheduleId)
-			.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+		ScheduleDetail detail = scheduleDetailRepository.findByIdAndSchedule_Id(detailId, scheduleId)
+				.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
 
 		scheduleDetailRepository.delete(detail);
 	}

--- a/src/main/java/com/ddd/oi/user/domain/User.java
+++ b/src/main/java/com/ddd/oi/user/domain/User.java
@@ -19,8 +19,7 @@ public class User extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "user_id")
-	private Long userId;
+	private Long id;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "login_type", nullable = false)


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #10 

## 📌 개요
- 한달 일정 조회 Api에 시작일자로 정렬로직을 추가하였습니다.
- GroupTag를  Jpa의 @CollectionTable로 매핑하는 방식으로 변경하였습니다.

## 🔁 변경 사항
- 모든 엔티티의 PK 필드를 id로 통일하였습니다.
- Swagger @Schema로  dto에 예시 값을 추가하였습니다.
- ScheduleTag,Moblity,GroupTag를 schedule/domain/enumType 폴더에 넣어두었습니다.
- Enum값을 스웨거에서 볼 수 있도록 enumController를 추가해두었습니다. 
- HealthCheckController를 추가하였습니다. 
## 📸 스크린샷 (선택)

## 👀 기타 더 이야기해볼 점 (선택)
- swagger에서 Enum값을 보여드릴 방법이 마땅히 떠오르지 않아 EnumController를 도입하였습니다. @bangyewon 
## 💬 리뷰 요구사항 (선택)

## ✅ 체크 리스트
- [X] PR 템플릿에 맞추어 작성했어요.
- [X] 변경 내용에 대한 테스트를 진행했어요.
- [X] 프로그램이 정상적으로 동작해요.
- [X] PR에 적절한 라벨을 선택했어요.
- [X] 불필요한 코드는 삭제했어요.
