### PR TITLE
✅ Refactor: Test 코드 추가 및 일정 상세 Api 변경

### DIFF
--- a/src/main/java/com/ddd/oi/common/response/ErrorCode.java
+++ b/src/main/java/com/ddd/oi/common/response/ErrorCode.java
@@ -18,7 +18,13 @@ public enum ErrorCode {
     // 스케줄 관련 에러
     END_DATE_BEFORE_START_DATE("종료 날짜는 시작 날짜 이후로 설정해야 합니다.", HttpStatus.BAD_REQUEST),
     DUPLICATE_GROUP_NAME("중복된 일행 이름이 포함되어 있습니다.", HttpStatus.BAD_REQUEST),
-    SCHEDULE_LIMIT_EXCEEDED("하루에 최대 3개의 일정만 등록할 수 있습니다.",HttpStatus.BAD_REQUEST);
+    SCHEDULE_LIMIT_EXCEEDED("하루에 최대 3개의 일정만 등록할 수 있습니다.", HttpStatus.BAD_REQUEST),
+
+    // 스케줄 상세 관련 세어
+    INVALID_LATITUDE("유효하지 않은 위도입니다. -90에서 90 사이의 값을 입력해주세요.", HttpStatus.BAD_REQUEST),
+    INVALID_LONGITUDE("유효하지 않은 경도입니다. -180에서 180 사이의 값을 입력해주세요.", HttpStatus.BAD_REQUEST),
+    INVALID_TARGET_DATE("시작 시간은 현재 시간 이후로 설정해야 합니다.", HttpStatus.BAD_REQUEST);
+
 
     private final String message;
     private final HttpStatus httpStatus;
@@ -26,4 +32,4 @@ public enum ErrorCode {
     public int getStatusCode() {
         return httpStatus.value();
     }
-}
+    }

--- a/src/main/java/com/ddd/oi/schedule_detail/controller/ScheduleDetailController.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/controller/ScheduleDetailController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.ddd.oi.common.response.CustomApiResponse;
 import com.ddd.oi.schedule_detail.dto.request.CreateDetailRequest;
 import com.ddd.oi.schedule_detail.dto.request.UpdateDetailRequest;
+import com.ddd.oi.schedule_detail.dto.response.ScheduleDetailGroupedResponse;
 import com.ddd.oi.schedule_detail.dto.response.ScheduleDetailResponse;
 import com.ddd.oi.schedule_detail.service.ScheduleDetailService;
 
@@ -35,12 +36,9 @@ public class ScheduleDetailController {
 
 	@GetMapping
 	@Operation(summary = "세부일정 목록 조회", description = "세부일정 목록 조회 API")
-	public CustomApiResponse<List<ScheduleDetailResponse>> getDetails(
-		@PathVariable Long scheduleId,
-		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate) {
-
-		List<ScheduleDetailResponse> result = scheduleDetailService.getDetails(scheduleId, targetDate);
-		return CustomApiResponse.success(result,200,"세부 일정 목록 조회 성공");
+	public CustomApiResponse<List<ScheduleDetailGroupedResponse>> getDetails(@PathVariable Long scheduleId) {
+		List<ScheduleDetailGroupedResponse> result = scheduleDetailService.getGroupedDetails(scheduleId);
+		return CustomApiResponse.success(result, 200, "세부 일정 목록 조회 성공");
 	}
 
 	@PostMapping

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/request/CreateDetailRequest.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/request/CreateDetailRequest.java
@@ -9,15 +9,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateDetailRequest(
-		@NotNull @JsonFormat(pattern = "HH:mm") @Schema(type = "string", format = "time", pattern = "HH:mm", example = "14:30", description = "시작 시간") LocalTime startTime,
+		@NotNull @JsonFormat(pattern = "HH:mm") LocalTime startTime,
 
-		@Schema(description = "메모", example = "아침 식사 후 출발") String memo,
+		 String memo,
 
-		@NotNull @Schema(description = "날짜", example = "2025-07-01") LocalDate targetDate,
+		@NotNull  LocalDate targetDate,
 
-		@NotNull @Schema(description = "장소명", example = "서울역") String spotName,
+		@NotNull String spotName,
 
-		@NotNull @Schema(description = "위도", example = "37.554722") Double latitude,
+		@NotNull  Double latitude,
 
-		@NotNull @Schema(description = "경도", example = "126.970833") Double longitude) {
+		@NotNull Double longitude) {
 }

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/request/CreateDetailRequest.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/request/CreateDetailRequest.java
@@ -7,6 +7,8 @@ import java.time.LocalTime;
 import com.ddd.oi.common.annotation.NotBlankNullable;
 import com.ddd.oi.common.exception.OiException;
 import com.ddd.oi.common.response.ErrorCode;
+import com.ddd.oi.schedule.domain.Schedule;
+import com.ddd.oi.schedule_detail.domain.ScheduleDetail;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -40,5 +42,15 @@ public record CreateDetailRequest(
 				throw new OiException(ErrorCode.INVALID_TARGET_DATE);
 			}
 		}
+	}
+	public ScheduleDetail toEntity(){
+		return ScheduleDetail.builder()
+				.startTime(startTime)
+				.targetDate(targetDate)
+				.memo(memo)
+				.spotName(spotName)
+				.latitude(latitude)
+				.longitude(longitude)
+				.build();
 	}
 }

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/request/CreateDetailRequest.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/request/CreateDetailRequest.java
@@ -1,23 +1,44 @@
 package com.ddd.oi.schedule_detail.dto.request;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+import com.ddd.oi.common.annotation.NotBlankNullable;
+import com.ddd.oi.common.exception.OiException;
+import com.ddd.oi.common.response.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateDetailRequest(
-		@NotNull @JsonFormat(pattern = "HH:mm") LocalTime startTime,
+	@NotBlankNullable(message = "시작 시간을 정해주세요.")
+	@JsonFormat(pattern = "HH:mm") LocalTime startTime,
 
-		 String memo,
+	@NotBlankNullable(message = "날짜를 정해주세요.")
+	LocalDate targetDate,
+	String memo,
 
-		@NotNull  LocalDate targetDate,
+	@NotBlankNullable(message = "장소명을 입력해주세요.")
+	String spotName,
 
-		@NotNull String spotName,
+	@NotBlankNullable(message = "위도를 입력해주세요.")
+	Double latitude,
 
-		@NotNull  Double latitude,
-
-		@NotNull Double longitude) {
+	@NotBlankNullable(message = "경도를 입력해주세요.")
+	Double longitude) {
+	public CreateDetailRequest {
+		if (latitude < -90 || latitude > 90) {
+			throw new OiException(ErrorCode.INVALID_LATITUDE);
+		}
+		if (longitude < -180 || longitude > 180) {
+			throw new OiException(ErrorCode.INVALID_LONGITUDE);
+		}
+		if (targetDate != null) {
+			if (targetDate.isBefore(LocalDate.now())) {
+				throw new OiException(ErrorCode.INVALID_TARGET_DATE);
+			}
+		}
+	}
 }

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/request/UpdateDetailRequest.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/request/UpdateDetailRequest.java
@@ -1,6 +1,9 @@
 package com.ddd.oi.schedule_detail.dto.request;
 
 import com.ddd.oi.common.annotation.NotBlankNullable;
+import com.ddd.oi.common.exception.OiException;
+import com.ddd.oi.common.response.ErrorCode;
+import com.ddd.oi.schedule_detail.domain.ScheduleDetail;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,4 +28,27 @@ public record UpdateDetailRequest(
 
 	@NotBlankNullable(message = "경도를 입력해주세요.")
 	Double longitude) {
+	public UpdateDetailRequest {
+		if (latitude < -90 || latitude > 90) {
+			throw new OiException(ErrorCode.INVALID_LATITUDE);
+		}
+		if (longitude < -180 || longitude > 180) {
+			throw new OiException(ErrorCode.INVALID_LONGITUDE);
+		}
+		if (targetDate != null) {
+			if (targetDate.isBefore(LocalDate.now())) {
+				throw new OiException(ErrorCode.INVALID_TARGET_DATE);
+			}
+		}
+	}
+	public ScheduleDetail toEntity(){
+		return ScheduleDetail.builder()
+			.startTime(startTime)
+			.targetDate(targetDate)
+			.memo(memo)
+			.spotName(spotName)
+			.latitude(latitude)
+			.longitude(longitude)
+			.build();
+	}
 }

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/request/UpdateDetailRequest.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/request/UpdateDetailRequest.java
@@ -1,21 +1,23 @@
 package com.ddd.oi.schedule_detail.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record UpdateDetailRequest(
-		@NotNull @JsonFormat(pattern = "HH:mm") @Schema(type = "string", format = "time", pattern = "HH:mm", example = "14:30", description = "시작 시간") LocalTime startTime,
+	@NotNull @JsonFormat(pattern = "HH:mm") LocalTime startTime,
 
-		@NotNull @Schema(description = "날짜", example = "2025-07-01") LocalDate targetDate,
+	@NotNull LocalDate targetDate,
 
-		@Schema(description = "메모", example = "아침 식사 후 출발") String memo,
+	String memo,
 
-		@NotNull @Schema(description = "장소명", example = "서울역") String spotName,
+	@NotNull String spotName,
 
-		@NotNull @Schema(description = "위도", example = "37.554722") Double latitude,
+	@NotNull Double latitude,
 
-		@NotNull @Schema(description = "경도", example = "126.970833") Double longitude) {
+	@NotNull Double longitude) {
 }

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/request/UpdateDetailRequest.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/request/UpdateDetailRequest.java
@@ -1,5 +1,6 @@
 package com.ddd.oi.schedule_detail.dto.request;
 
+import com.ddd.oi.common.annotation.NotBlankNullable;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,15 +10,19 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record UpdateDetailRequest(
-	@NotNull @JsonFormat(pattern = "HH:mm") LocalTime startTime,
+	@NotBlankNullable(message = "시작 시간을 정해주세요.")
+	@JsonFormat(pattern = "HH:mm") LocalTime startTime,
 
-	@NotNull LocalDate targetDate,
-
+	@NotBlankNullable(message = "날짜를 정해주세요.")
+	LocalDate targetDate,
 	String memo,
 
-	@NotNull String spotName,
+	@NotBlankNullable(message = "장소명을 입력해주세요.")
+	String spotName,
 
-	@NotNull Double latitude,
+	@NotBlankNullable(message = "위도를 입력해주세요.")
+	Double latitude,
 
-	@NotNull Double longitude) {
+	@NotBlankNullable(message = "경도를 입력해주세요.")
+	Double longitude) {
 }

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/request/UpdateDetailRequest.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/request/UpdateDetailRequest.java
@@ -41,14 +41,4 @@ public record UpdateDetailRequest(
 			}
 		}
 	}
-	public ScheduleDetail toEntity(){
-		return ScheduleDetail.builder()
-			.startTime(startTime)
-			.targetDate(targetDate)
-			.memo(memo)
-			.spotName(spotName)
-			.latitude(latitude)
-			.longitude(longitude)
-			.build();
-	}
 }

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/response/ScheduleDetailGroupedResponse.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/response/ScheduleDetailGroupedResponse.java
@@ -1,10 +1,13 @@
 package com.ddd.oi.schedule_detail.dto.response;
 
 import com.ddd.oi.schedule_detail.domain.ScheduleDetail;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.LocalDate;
 import java.util.List;
 
 public record ScheduleDetailGroupedResponse(
+	@JsonFormat(pattern = "yyyy-MM-dd")
 	LocalDate targetDate,
 	List<ScheduleDetailResponse> details
 ) {

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/response/ScheduleDetailGroupedResponse.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/response/ScheduleDetailGroupedResponse.java
@@ -1,0 +1,17 @@
+package com.ddd.oi.schedule_detail.dto.response;
+
+import com.ddd.oi.schedule_detail.domain.ScheduleDetail;
+import java.time.LocalDate;
+import java.util.List;
+
+public record ScheduleDetailGroupedResponse(
+	LocalDate targetDate,
+	List<ScheduleDetailResponse> details
+) {
+	public static ScheduleDetailGroupedResponse from(LocalDate targetDate, List<ScheduleDetail> details) {
+		return new ScheduleDetailGroupedResponse(
+			targetDate,
+			details.stream().map(ScheduleDetailResponse::from).toList()
+		);
+	}
+}

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/response/ScheduleDetailGroupedResponse.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/response/ScheduleDetailGroupedResponse.java
@@ -6,6 +6,9 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.util.List;
 
+import lombok.Builder;
+
+@Builder
 public record ScheduleDetailGroupedResponse(
 	@JsonFormat(pattern = "yyyy-MM-dd")
 	LocalDate targetDate,

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/response/ScheduleDetailResponse.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/response/ScheduleDetailResponse.java
@@ -11,7 +11,10 @@ import lombok.Builder;
 @Builder
 public record ScheduleDetailResponse(
 	Long id,
-	@JsonFormat(pattern = "HH:mm") LocalTime startTime,
+	@JsonFormat(pattern = "HH:mm")
+	LocalTime startTime,
+
+	@JsonFormat(pattern = "yyyy-MM-dd")
 	LocalDate targetDate,
 	String spotName,
 	Double latitude,

--- a/src/main/java/com/ddd/oi/schedule_detail/dto/response/ScheduleDetailResponse.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/dto/response/ScheduleDetailResponse.java
@@ -1,7 +1,6 @@
 package com.ddd.oi.schedule_detail.dto.response;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import com.ddd.oi.schedule_detail.domain.ScheduleDetail;
@@ -11,19 +10,21 @@ import lombok.Builder;
 
 @Builder
 public record ScheduleDetailResponse(
-		Long id,
-		@JsonFormat(pattern = "HH:mm") LocalTime startTime,
-		String spotName,
-		Double latitude,
-		Double longitude,
-		String memo) {
+	Long id,
+	@JsonFormat(pattern = "HH:mm") LocalTime startTime,
+	LocalDate targetDate,
+	String spotName,
+	Double latitude,
+	Double longitude,
+	String memo) {
 	public static ScheduleDetailResponse from(ScheduleDetail entity) {
 		return new ScheduleDetailResponse(
-				entity.getId(),
-				entity.getStartTime(),
-				entity.getSpotName(),
-				entity.getLatitude(),
-				entity.getLongitude(),
-				entity.getMemo());
+			entity.getId(),
+			entity.getStartTime(),
+			entity.getTargetDate(),
+			entity.getSpotName(),
+			entity.getLatitude(),
+			entity.getLongitude(),
+			entity.getMemo());
 	}
 }

--- a/src/main/java/com/ddd/oi/schedule_detail/repository/ScheduleDetailRepository.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/repository/ScheduleDetailRepository.java
@@ -1,6 +1,8 @@
 package com.ddd.oi.schedule_detail.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -12,7 +14,7 @@ import com.ddd.oi.schedule_detail.domain.ScheduleDetail;
 
 @Repository
 public interface ScheduleDetailRepository extends JpaRepository<ScheduleDetail, Long> {
-	List<ScheduleDetail> findBySchedule_IdAndTargetDate(Long scheduleId, LocalDate targetDate);
-
+	@Query("SELECT sd FROM ScheduleDetail sd WHERE sd.schedule.id = :scheduleId ORDER BY sd.targetDate, sd.startTime")
+	List<ScheduleDetail> findByScheduleId(@Param("scheduleId") Long scheduleId);
 	Optional<ScheduleDetail> findByIdAndSchedule_Id(Long scheduleDetailId, Long scheduleId);
 }

--- a/src/main/java/com/ddd/oi/schedule_detail/service/ScheduleDetailService.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/service/ScheduleDetailService.java
@@ -7,6 +7,7 @@ import com.ddd.oi.schedule.repository.ScheduleRepository;
 import com.ddd.oi.schedule_detail.domain.ScheduleDetail;
 import com.ddd.oi.schedule_detail.dto.request.CreateDetailRequest;
 import com.ddd.oi.schedule_detail.dto.request.UpdateDetailRequest;
+import com.ddd.oi.schedule_detail.dto.response.ScheduleDetailGroupedResponse;
 import com.ddd.oi.schedule_detail.dto.response.ScheduleDetailResponse;
 import com.ddd.oi.schedule_detail.repository.ScheduleDetailRepository;
 
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,12 +28,15 @@ public class ScheduleDetailService {
 	private final ScheduleRepository scheduleRepository;
 
 	@Transactional(readOnly = true)
-	public List<ScheduleDetailResponse> getDetails(Long scheduleId, LocalDate targetDate) {
+	public List<ScheduleDetailGroupedResponse> getGroupedDetails(Long scheduleId) {
 		validateScheduleById(scheduleId);
 
-		return scheduleDetailRepository.findBySchedule_IdAndTargetDate(scheduleId, targetDate)
+		return scheduleDetailRepository.findByScheduleId(scheduleId)
 			.stream()
-			.map(ScheduleDetailResponse::from)
+			.collect(Collectors.groupingBy(ScheduleDetail::getTargetDate))
+			.entrySet()
+			.stream()
+			.map(entry -> ScheduleDetailGroupedResponse.from(entry.getKey(), entry.getValue()))
 			.toList();
 	}
 
@@ -39,7 +44,8 @@ public class ScheduleDetailService {
 	public void createDetail(Long scheduleId, CreateDetailRequest request) {
 		Schedule schedule = validateScheduleById(scheduleId);
 
-		if (request.targetDate().isBefore(schedule.getStartDate()) || request.targetDate().isAfter(schedule.getEndDate())) {
+		if (request.targetDate().isBefore(schedule.getStartDate()) || request.targetDate()
+			.isAfter(schedule.getEndDate())) {
 			throw new OiException(ErrorCode.INVALID_TARGET_DATE);
 		}
 		ScheduleDetail detail = request.toEntity();

--- a/src/main/java/com/ddd/oi/schedule_detail/service/ScheduleDetailService.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/service/ScheduleDetailService.java
@@ -8,7 +8,6 @@ import com.ddd.oi.schedule_detail.domain.ScheduleDetail;
 import com.ddd.oi.schedule_detail.dto.request.CreateDetailRequest;
 import com.ddd.oi.schedule_detail.dto.request.UpdateDetailRequest;
 import com.ddd.oi.schedule_detail.dto.response.ScheduleDetailGroupedResponse;
-import com.ddd.oi.schedule_detail.dto.response.ScheduleDetailResponse;
 import com.ddd.oi.schedule_detail.repository.ScheduleDetailRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,7 +27,7 @@ public class ScheduleDetailService {
 
 	@Transactional(readOnly = true)
 	public List<ScheduleDetailGroupedResponse> getGroupedDetails(Long scheduleId) {
-		validateScheduleById(scheduleId);
+		findExistingSchedule(scheduleId);
 
 		return scheduleDetailRepository.findByScheduleId(scheduleId)
 			.stream()
@@ -43,7 +41,7 @@ public class ScheduleDetailService {
 
 	@Transactional
 	public void createDetail(Long scheduleId, CreateDetailRequest request) {
-		Schedule schedule = validateScheduleById(scheduleId);
+		Schedule schedule = findExistingSchedule(scheduleId);
 
 		if (request.targetDate().isBefore(schedule.getStartDate()) || request.targetDate()
 			.isAfter(schedule.getEndDate())) {
@@ -55,8 +53,8 @@ public class ScheduleDetailService {
 
 	@Transactional
 	public void updateDetail(Long scheduleId, Long detailId, UpdateDetailRequest request) {
-		validateScheduleById(scheduleId);
-		ScheduleDetail detail = validateScheduleDetailByIdAndScheduleId(detailId, scheduleId);
+		findExistingSchedule(scheduleId);
+		ScheduleDetail detail = findExistingScheduleDetail(detailId, scheduleId);
 
 		detail.update(
 			request.startTime(),
@@ -68,18 +66,18 @@ public class ScheduleDetailService {
 
 	@Transactional
 	public void deleteDetail(Long scheduleId, Long detailId) {
-		validateScheduleById(scheduleId);
-		ScheduleDetail detail = validateScheduleDetailByIdAndScheduleId(detailId, scheduleId);
+		findExistingSchedule(scheduleId);
+		ScheduleDetail detail = findExistingScheduleDetail(detailId, scheduleId);
 
 		scheduleDetailRepository.delete(detail);
 	}
 
-	private Schedule validateScheduleById(Long scheduleId) {
+	private Schedule findExistingSchedule(Long scheduleId) {
 		return scheduleRepository.findById(scheduleId)
 			.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
 	}
 
-	private ScheduleDetail validateScheduleDetailByIdAndScheduleId(Long detailId, Long scheduleId) {
+	private ScheduleDetail findExistingScheduleDetail(Long detailId, Long scheduleId) {
 		return scheduleDetailRepository.findByIdAndSchedule_Id(detailId, scheduleId)
 			.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
 	}

--- a/src/main/java/com/ddd/oi/schedule_detail/service/ScheduleDetailService.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/service/ScheduleDetailService.java
@@ -40,6 +40,7 @@ public class ScheduleDetailService {
 			.toList();
 	}
 
+
 	@Transactional
 	public void createDetail(Long scheduleId, CreateDetailRequest request) {
 		Schedule schedule = validateScheduleById(scheduleId);

--- a/src/main/java/com/ddd/oi/schedule_detail/service/ScheduleDetailService.java
+++ b/src/main/java/com/ddd/oi/schedule_detail/service/ScheduleDetailService.java
@@ -7,7 +7,7 @@ import com.ddd.oi.schedule.repository.ScheduleRepository;
 import com.ddd.oi.schedule_detail.domain.ScheduleDetail;
 import com.ddd.oi.schedule_detail.dto.request.CreateDetailRequest;
 import com.ddd.oi.schedule_detail.dto.request.UpdateDetailRequest;
-import com.ddd.oi.schedule_detail.dto.response.*;
+import com.ddd.oi.schedule_detail.dto.response.ScheduleDetailResponse;
 import com.ddd.oi.schedule_detail.repository.ScheduleDetailRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -27,54 +27,53 @@ public class ScheduleDetailService {
 
 	@Transactional(readOnly = true)
 	public List<ScheduleDetailResponse> getDetails(Long scheduleId, LocalDate targetDate) {
-		Schedule schedule = scheduleRepository.findById(scheduleId)
-				.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+		validateScheduleById(scheduleId);
 
 		return scheduleDetailRepository.findBySchedule_IdAndTargetDate(scheduleId, targetDate)
-				.stream()
-				.map(ScheduleDetailResponse::from)
-				.toList();
+			.stream()
+			.map(ScheduleDetailResponse::from)
+			.toList();
 	}
 
 	@Transactional
 	public void createDetail(Long scheduleId, CreateDetailRequest request) {
-		Schedule schedule = scheduleRepository.findById(scheduleId)
-				.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+		Schedule schedule = validateScheduleById(scheduleId);
 
-		ScheduleDetail detail = ScheduleDetail.builder()
-				.schedule(schedule)
-				.startTime(request.startTime())
-				.targetDate(request.targetDate())
-				.memo(request.memo())
-				.spotName(request.spotName())
-				.latitude(request.latitude())
-				.longitude(request.longitude())
-				.build();
-
-		ScheduleDetail saved = scheduleDetailRepository.save(detail);
+		if (request.targetDate().isBefore(schedule.getStartDate()) || request.targetDate().isAfter(schedule.getEndDate())) {
+			throw new OiException(ErrorCode.INVALID_TARGET_DATE);
+		}
+		ScheduleDetail detail = request.toEntity();
+		scheduleDetailRepository.save(detail);
 	}
 
 	@Transactional
 	public void updateDetail(Long scheduleId, Long detailId, UpdateDetailRequest request) {
-		Schedule schedule = scheduleRepository.findById(scheduleId)
-				.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
-
-		ScheduleDetail detail = scheduleDetailRepository.findByIdAndSchedule_Id(detailId, scheduleId)
-				.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+		validateScheduleById(scheduleId);
+		ScheduleDetail detail = validateScheduleDetailByIdAndScheduleId(detailId, scheduleId);
 
 		detail.update(
-				request.startTime(),
-				request.memo(),
-				request.spotName(),
-				request.latitude(),
-				request.longitude());
+			request.startTime(),
+			request.memo(),
+			request.spotName(),
+			request.latitude(),
+			request.longitude());
 	}
 
 	@Transactional
 	public void deleteDetail(Long scheduleId, Long detailId) {
-		ScheduleDetail detail = scheduleDetailRepository.findByIdAndSchedule_Id(detailId, scheduleId)
-				.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+		validateScheduleById(scheduleId);
+		ScheduleDetail detail = validateScheduleDetailByIdAndScheduleId(detailId, scheduleId);
 
 		scheduleDetailRepository.delete(detail);
+	}
+
+	private Schedule validateScheduleById(Long scheduleId) {
+		return scheduleRepository.findById(scheduleId)
+			.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
+	}
+
+	private ScheduleDetail validateScheduleDetailByIdAndScheduleId(Long detailId, Long scheduleId) {
+		return scheduleDetailRepository.findByIdAndSchedule_Id(detailId, scheduleId)
+			.orElseThrow(() -> new OiException(ErrorCode.ENTITY_NOT_FOUND));
 	}
 }

--- a/src/test/java/com/ddd/oi/schedule_detail/controller/ScheduleDetailControllerTest.java
+++ b/src/test/java/com/ddd/oi/schedule_detail/controller/ScheduleDetailControllerTest.java
@@ -1,0 +1,126 @@
+package com.ddd.oi.schedule_detail.controller;
+
+import com.ddd.oi.common.response.CustomApiResponse;
+import com.ddd.oi.schedule_detail.dto.request.CreateDetailRequest;
+import com.ddd.oi.schedule_detail.dto.request.UpdateDetailRequest;
+import com.ddd.oi.schedule_detail.dto.response.ScheduleDetailGroupedResponse;
+import com.ddd.oi.schedule_detail.dto.response.ScheduleDetailResponse;
+import com.ddd.oi.schedule_detail.service.ScheduleDetailService;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class ScheduleDetailControllerTest {
+
+	private final ScheduleDetailService scheduleDetailService = mock(ScheduleDetailService.class);
+	private final MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new ScheduleDetailController(scheduleDetailService)).build();
+
+	@Test
+	@DisplayName("세부일정 목록 조회 성공")
+	void 스케줄_세부일정_조회_성공() throws Exception {
+		// Given
+		when(scheduleDetailService.getGroupedDetails(1L)).thenReturn(List.of(
+			new ScheduleDetailGroupedResponse(LocalDate.of(2025, 7, 1), List.of(
+				new ScheduleDetailResponse(1L, LocalTime.of(10, 0), LocalDate.of(2025, 7, 1), "spot1", 10.0, 20.0, "memo1"),
+				new ScheduleDetailResponse(2L, LocalTime.of(11, 0), LocalDate.of(2025, 7, 1), "spot2", 15.0, 25.0, "memo2")
+			)),
+			new ScheduleDetailGroupedResponse(LocalDate.of(2025, 7, 2), List.of(
+				new ScheduleDetailResponse(3L, LocalTime.of(12, 0), LocalDate.of(2025, 7, 2), "spot3", 20.0, 30.0, "memo3"),
+				new ScheduleDetailResponse(4L, LocalTime.of(13, 0), LocalDate.of(2025, 7, 2), "spot4", 25.0, 35.0, "memo4")
+			))
+		));
+
+		// When & Then
+		mockMvc.perform(get("/api/v1/schedules/1/details"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data[0].targetDate").value("2025-07-01"))
+			.andExpect(jsonPath("$.data[0].details[0].memo").value("memo1"))
+			.andExpect(jsonPath("$.data[0].details[1].spotName").value("spot2"))
+			.andExpect(jsonPath("$.data[1].targetDate").value("2025-07-02"))
+			.andExpect(jsonPath("$.data[1].details[0].latitude").value(20.0))
+			.andExpect(jsonPath("$.data[1].details[1].longitude").value(35.0));
+	}
+
+	@Test
+	@DisplayName("세부일정 생성 요청 성공")
+	void 스케줄_상세_생성_요청_성공() throws Exception {
+		// Given
+		CreateDetailRequest request = new CreateDetailRequest(
+			LocalTime.now().plusHours(1), // Ensure startTime is after the current time
+			LocalDate.of(2026, 7, 1),
+			"memo",
+			"spot",
+			10.0,
+			20.0
+		);
+		doNothing().when(scheduleDetailService).createDetail(1L, request);
+
+		// When & Then
+		mockMvc.perform(post("/api/v1/schedules/1/details")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+            {
+                "startTime": "10:00",
+                "targetDate": "2026-07-01",
+                "memo": "memo",
+                "spotName": "spot",
+                "latitude": 10.0,
+                "longitude": 20.0
+            }
+        """))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("세부일정 수정 요청 성공")
+	void 스케줄_상세_수정_요청_성공() throws Exception {
+		// Given
+		UpdateDetailRequest request = new UpdateDetailRequest(
+			LocalTime.now().plusHours(1),
+			LocalDate.of(2026, 11, 1),
+			"memo",
+			"spot",
+			10.0,
+			20.0
+		);
+		doNothing().when(scheduleDetailService).updateDetail(1L, 1L, request);
+
+		// When & Then
+		mockMvc.perform(put("/api/v1/schedules/1/details/1")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+            {
+                "startTime": "10:00",
+                "targetDate": "2026-11-01",
+                "memo": "memo",
+                "spotName": "spot",
+                "latitude": 10.0,
+                "longitude": 20.0
+            }
+        """))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("세부일정 삭제 요청 성공")
+	void 스케줄_상세_삭제요청_성공() throws Exception {
+		// Given
+		doNothing().when(scheduleDetailService).deleteDetail(1L, 1L);
+
+		// When & Then
+		mockMvc.perform(delete("/api/v1/schedules/1/details/1"))
+			.andExpect(status().isOk());
+	}
+}

--- a/src/test/java/com/ddd/oi/schedule_detail/controller/ScheduleDetailControllerTest.java
+++ b/src/test/java/com/ddd/oi/schedule_detail/controller/ScheduleDetailControllerTest.java
@@ -32,14 +32,52 @@ class ScheduleDetailControllerTest {
 	void 스케줄_세부일정_조회_성공() throws Exception {
 		// Given
 		when(scheduleDetailService.getGroupedDetails(1L)).thenReturn(List.of(
-			new ScheduleDetailGroupedResponse(LocalDate.of(2025, 7, 1), List.of(
-				new ScheduleDetailResponse(1L, LocalTime.of(10, 0), LocalDate.of(2025, 7, 1), "spot1", 10.0, 20.0, "memo1"),
-				new ScheduleDetailResponse(2L, LocalTime.of(11, 0), LocalDate.of(2025, 7, 1), "spot2", 15.0, 25.0, "memo2")
-			)),
-			new ScheduleDetailGroupedResponse(LocalDate.of(2025, 7, 2), List.of(
-				new ScheduleDetailResponse(3L, LocalTime.of(12, 0), LocalDate.of(2025, 7, 2), "spot3", 20.0, 30.0, "memo3"),
-				new ScheduleDetailResponse(4L, LocalTime.of(13, 0), LocalDate.of(2025, 7, 2), "spot4", 25.0, 35.0, "memo4")
-			))
+			ScheduleDetailGroupedResponse.builder()
+				.targetDate(LocalDate.of(2025, 7, 1))
+				.details(List.of(
+					ScheduleDetailResponse.builder()
+						.id(1L)
+						.startTime(LocalTime.of(10, 0))
+						.targetDate(LocalDate.of(2025, 7, 1))
+						.spotName("spot1")
+						.latitude(10.0)
+						.longitude(20.0)
+						.memo("memo1")
+						.build(),
+					ScheduleDetailResponse.builder()
+						.id(2L)
+						.startTime(LocalTime.of(11, 0))
+						.targetDate(LocalDate.of(2025, 7, 1))
+						.spotName("spot2")
+						.latitude(15.0)
+						.longitude(25.0)
+						.memo("memo2")
+						.build()
+				))
+				.build(),
+			ScheduleDetailGroupedResponse.builder()
+				.targetDate(LocalDate.of(2025, 7, 2))
+				.details(List.of(
+					ScheduleDetailResponse.builder()
+						.id(3L)
+						.startTime(LocalTime.of(12, 0))
+						.targetDate(LocalDate.of(2025, 7, 2))
+						.spotName("spot3")
+						.latitude(20.0)
+						.longitude(30.0)
+						.memo("memo3")
+						.build(),
+					ScheduleDetailResponse.builder()
+						.id(4L)
+						.startTime(LocalTime.of(13, 0))
+						.targetDate(LocalDate.of(2025, 7, 2))
+						.spotName("spot4")
+						.latitude(25.0)
+						.longitude(35.0)
+						.memo("memo4")
+						.build()
+				))
+				.build()
 		));
 
 		// When & Then

--- a/src/test/java/com/ddd/oi/schedule_detail/dto/ScheduleDetailRequestTest.java
+++ b/src/test/java/com/ddd/oi/schedule_detail/dto/ScheduleDetailRequestTest.java
@@ -1,0 +1,99 @@
+package com.ddd.oi.schedule_detail.dto;
+
+import com.ddd.oi.common.exception.OiException;
+import com.ddd.oi.common.response.ErrorCode;
+import com.ddd.oi.schedule_detail.dto.request.CreateDetailRequest;
+import com.ddd.oi.schedule_detail.dto.request.UpdateDetailRequest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ScheduleDetailRequestTest {
+
+	@Test
+	@DisplayName("CreateDetailRequest - 위도가 범위를 벗어나면 예외 발생")
+	void 위도값_범위_초과시_예외발생() {
+		OiException ex = assertThrows(OiException.class, () ->
+			new CreateDetailRequest(
+				LocalTime.of(9, 0),
+				LocalDate.of(2026, 5, 3),
+				"메모",
+				"장소",
+				100.0,
+				127.0
+			)
+		);
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_LATITUDE);
+	}
+
+	@Test
+	@DisplayName("CreateDetailRequest - 경도가 범위를 벗어나면 예외 발생")
+	void 경도값_범위_초과시_예외발생() {
+		OiException ex = assertThrows(OiException.class, () ->
+			new CreateDetailRequest(
+				LocalTime.of(9, 0),
+				LocalDate.of(2026, 5, 3),
+				"메모",
+				"장소",
+				37.5,
+				200.0
+			)
+		);
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_LONGITUDE);
+	}
+	@Test
+	@DisplayName("CreateDetailRequest - targetDate가 현재보다 과거인 경우 예외 발생")
+	void 현재보다_과거인_경우_예외_발생() {
+		LocalTime pastTime = LocalTime.now().minusHours(1);
+
+		OiException ex = assertThrows(OiException.class, () ->
+			new CreateDetailRequest(
+				pastTime,
+				LocalDate.of(2024, 5, 3),
+				"메모",
+				"장소",
+				37.5,
+				127.0
+			)
+		);
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_TARGET_DATE);
+	}
+
+	@Test
+	@DisplayName("UpdateDetailRequest - 위도가 범위를 벗어나면 예외 발생")
+	void 위도값_초과시_예외() {
+		OiException ex = assertThrows(OiException.class, () ->
+			new UpdateDetailRequest(
+				LocalTime.NOON,
+				LocalDate.of(2026, 5, 5),
+				"메모",
+				"장소",
+				-100.0,
+				126.0
+			)
+		);
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_LATITUDE);
+	}
+
+	@Test
+	@DisplayName("UpdateDetailRequest - 경도가 범위를 벗어나면 예외 발생")
+	void 경도_예외() {
+		OiException ex = assertThrows(OiException.class, () ->
+			new UpdateDetailRequest(
+				LocalTime.NOON,
+				LocalDate.of(2026, 5, 5),
+				"메모",
+				"장소",
+				36.0,
+				-200.0
+			)
+		);
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_LONGITUDE);
+	}
+}

--- a/src/test/java/com/ddd/oi/schedule_detail/service/ScheduleDetailServiceTest.java
+++ b/src/test/java/com/ddd/oi/schedule_detail/service/ScheduleDetailServiceTest.java
@@ -1,0 +1,132 @@
+package com.ddd.oi.schedule_detail.service;
+
+import com.ddd.oi.common.exception.OiException;
+import com.ddd.oi.common.response.ErrorCode;
+import com.ddd.oi.schedule.domain.Schedule;
+import com.ddd.oi.schedule.repository.ScheduleRepository;
+import com.ddd.oi.schedule_detail.domain.ScheduleDetail;
+import com.ddd.oi.schedule_detail.dto.request.CreateDetailRequest;
+import com.ddd.oi.schedule_detail.dto.request.UpdateDetailRequest;
+import com.ddd.oi.schedule_detail.repository.ScheduleDetailRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduleDetailServiceTest {
+
+    @InjectMocks
+    private ScheduleDetailService service;
+
+    @Mock
+    private ScheduleRepository scheduleRepository;
+
+    @Mock
+    private ScheduleDetailRepository scheduleDetailRepository;
+
+    private Schedule schedule;
+
+    @BeforeEach
+    void setup() {
+        schedule = Schedule.builder()
+            .id(1L)
+            .scheduleTitle("테스트 일정")
+            .startDate(LocalDate.of(2026, 5, 1))
+            .endDate(LocalDate.of(2026, 5, 10))
+            .build();
+    }
+
+    @Test
+    @DisplayName("세부 일정 생성에 성공한다")
+    void 세부_일정_생성_성공() {
+        CreateDetailRequest request = new CreateDetailRequest(
+            LocalTime.of(10, 0),
+            LocalDate.of(2026, 5, 3),
+            "메모입니다",
+            "강남역",
+            37.5,
+            127.0
+        );
+        when(scheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+        service.createDetail(1L, request);
+        verify(scheduleDetailRepository).save(any(ScheduleDetail.class));
+    }
+
+    @Test
+    @DisplayName("세부 일정 생성 시 날짜가 범위를 벗어나면 예외가 발생한다")
+    void 날짜_범위_벗어나면_예외_발생() {
+        CreateDetailRequest request = new CreateDetailRequest(
+            LocalTime.of(10, 0),
+            LocalDate.of(2026, 5, 20),
+            "메모입니다",
+            "강남역",
+            37.5,
+            127.0
+        );
+        when(scheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+        OiException exception = assertThrows(OiException.class, () ->
+            service.createDetail(1L, request));
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_TARGET_DATE);
+    }
+
+    @Test
+    @DisplayName("세부 일정 수정에 성공한다")
+    void 세부_일정_수정_성공() {
+        ScheduleDetail detail = mock(ScheduleDetail.class);
+        UpdateDetailRequest request = new UpdateDetailRequest(
+            LocalTime.of(13, 0),
+            LocalDate.of(2026, 5, 5),
+            "업데이트 메모",
+            "서울역",
+            36.5,
+            126.5
+        );
+        when(scheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+        when(scheduleDetailRepository.findByIdAndSchedule_Id(2L, 1L)).thenReturn(Optional.of(detail));
+        service.updateDetail(1L, 2L, request);
+        verify(detail).update(
+            eq(request.startTime()),
+            eq(request.memo()),
+            eq(request.spotName()),
+            eq(request.latitude()),
+            eq(request.longitude())
+        );
+    }
+
+    @Test
+    @DisplayName("세부 일정 삭제에 성공한다")
+    void 세부_일정_삭제_성공() {
+        ScheduleDetail detail = mock(ScheduleDetail.class);
+        when(scheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+        when(scheduleDetailRepository.findByIdAndSchedule_Id(2L, 1L)).thenReturn(Optional.of(detail));
+        service.deleteDetail(1L, 2L);
+        verify(scheduleDetailRepository).delete(detail);
+    }
+
+    @Test
+    @DisplayName("스케줄 또는 상세 ID가 존재하지 않으면 ENTITY_NOT_FOUND 예외가 발생한다")
+    void 공통_엔티티_없을때_예외_발생() {
+        when(scheduleRepository.findById(1L)).thenReturn(Optional.empty());
+        OiException ex1 = assertThrows(OiException.class, () ->
+            service.deleteDetail(1L, 2L));
+        assertThat(ex1.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND);
+
+        when(scheduleRepository.findById(1L)).thenReturn(Optional.of(schedule));
+        when(scheduleDetailRepository.findByIdAndSchedule_Id(2L, 1L)).thenReturn(Optional.empty());
+        OiException ex2 = assertThrows(OiException.class, () ->
+            service.deleteDetail(1L, 2L));
+        assertThat(ex2.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #21 

## 📌 개요
- ScheduleDetail 테스트 코드 추가

## 🔁 변경 사항
- ScheduleDetail 조회 방식 변경
- ScheduleDetail 상세 생성시 Schedule의 startDate,endDate 범위 내에서만 생성 가능하도록 변경
## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/9b291795-ee07-4e87-81b6-3cdbb0189a7c)

## 👀 기타 더 이야기해볼 점 (선택)
> 서비스에서 반복적으로 Schedule을 조회하고 검증하는 로직이 있어서 private 메서드로 빼고 공통화 시켰습니다. 
## 💬 리뷰 요구사항 (선택)

## ✅ 체크 리스트
- [X] PR 템플릿에 맞추어 작성했어요.
- [X] 변경 내용에 대한 테스트를 진행했어요.
- [X] 프로그램이 정상적으로 동작해요.
- [X] PR에 적절한 라벨을 선택했어요.
- [X] 불필요한 코드는 삭제했어요.
