### PR TITLE
🐛  Fix: 카카오 네이티브 Access Token 기반 프로필 조회 로직으로 수정 #69

### DIFF
--- a/src/main/java/com/ddd/oi/auth/dto/profile/KakaoDTO.java
+++ b/src/main/java/com/ddd/oi/auth/dto/profile/KakaoDTO.java
@@ -1,7 +1,10 @@
 package com.ddd.oi.auth.dto.profile;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class KakaoDTO {
 
@@ -16,23 +19,26 @@ public class KakaoDTO {
     }
 
     @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class KakaoProfile {
-        private Long id;
-        private KakaoAccount kakao_account;
+        private String id;
+        private String email;
+        private String nickname;
+//        private String profileImage;
 
-        @Getter
-        @JsonIgnoreProperties(ignoreUnknown = true)
-        public static class KakaoAccount {
-            private String email;
-            private Profile profile;
+        public static KakaoProfile fromJson(com.fasterxml.jackson.databind.JsonNode root) {
+            var kakaoAccount = root.path("kakao_account");
+            var profileNode = kakaoAccount.path("profile");
 
-            @Getter
-            @JsonIgnoreProperties(ignoreUnknown = true)
-            public static class Profile {
-                private String nickname;
-//                private String profile_image_url;
-            }
+            return KakaoProfile.builder()
+                    .id(root.path("id").asText())
+                    .email(kakaoAccount.path("email").asText(null))
+                    .nickname(profileNode.path("nickname").asText(null))
+//                    .profileImage(profileNode.path("profile_image_url").asText(null))
+                    .build();
         }
     }
 }

--- a/src/main/java/com/ddd/oi/common/utils/KakaoUtil.java
+++ b/src/main/java/com/ddd/oi/common/utils/KakaoUtil.java
@@ -3,7 +3,7 @@ package com.ddd.oi.common.utils;
 import com.ddd.oi.auth.dto.profile.KakaoDTO;
 import com.ddd.oi.common.exception.OiException;
 import com.ddd.oi.common.response.ErrorCode;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,25 +33,31 @@ public class KakaoUtil {
     @Value("${kakao.redirect-uri}")
     private String redirect;
     public KakaoDTO.KakaoProfile requestProfileByAccessToken(String oauthAccessToken) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + oauthAccessToken);
-
-        HttpEntity<Void> request = new HttpEntity<>(headers);
-
-        ResponseEntity<String> response = restTemplate.exchange(
-                "https://kapi.kakao.com/v2/user/me",
-                HttpMethod.GET,
-                request,
-                String.class
-        );
-
         try {
-            return objectMapper.readValue(response.getBody(), KakaoDTO.KakaoProfile.class);
-        } catch (JsonProcessingException e) {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(oauthAccessToken);
+
+            HttpEntity<Void> request = new HttpEntity<>(headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.GET,
+                    request,
+                    String.class
+            );
+
+            JsonNode root = objectMapper.readTree(response.getBody());
+            return KakaoDTO.KakaoProfile.fromJson(root);
+        } catch (HttpClientErrorException e) {
+            log.error("카카오 API 호출 실패: {}", e.getResponseBodyAsString());
+            throw new OiException(ErrorCode.TOKEN_INVALID);
+        } catch (Exception e) {
             log.error("카카오 사용자 정보 파싱 실패", e);
             throw new OiException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
+
+
 
     public String getKakaoUserId(String oauthAccessToken) {
         HttpHeaders headers = new HttpHeaders();


### PR DESCRIPTION
## 1. [수정 제목 또는 간단 설명]
- 🚨 문제점
    - 토큰 발급 주체가 달라서 인증 오류 발생

- 🔍 원인 분석
    - 기존 서버에서는 rest키로 토큰 사용했으나 앱 연동시 카카오 네이티브 키로 발급받은 Access Token을 서버에서 그대로 사용하게되어 문제 발생

- 💡 해결 방법
    - 서버가 REST API 키 전용 API를 네이티브 키 토큰으로 호출해서 인증 오류 발생 / 토큰 발급 주체 변경

- 🔄 수정 전/후 비교
  |수정 전|수정 후|
  |:-:|:-:|
  |<video src="" />|<video src="" />|
