### PR TITLE
:bug: hotfix: 카카오 providerId 수정 #88

### DIFF
--- a/src/main/java/com/ddd/oi/auth/service/AuthService.java
+++ b/src/main/java/com/ddd/oi/auth/service/AuthService.java
@@ -45,6 +45,20 @@ public class AuthService {
             case KAKAO -> {
                 var kakaoProfile = kakaoUtil.requestProfileByAccessToken(oauthAccessToken);
                 profile = new KakaoProfileAdapter(kakaoProfile);
+
+                User user = userRepository.findByProviderInfoAndProviderId(ProviderInfo.KAKAO, String.valueOf(kakaoProfile.getId()))
+                        .map(existingUser -> {
+                            existingUser.updateNickname(profile.getNickname());
+                            existingUser.updateEmail(profile.getEmail());
+                            return existingUser;
+                        })
+                        .orElseGet(() -> createNewUserWithProviderId(profile, kakaoProfile.getId()));
+
+                String accessToken = jwtUtil.createJwt(null, user.getEmail(), user.getRole().toString(), ACCESS_TOKEN_VALIDITY);
+                String refreshToken = jwtUtil.createJwt(null, user.getEmail(), user.getRole().toString(), REFRESH_TOKEN_VALIDITY);
+                redisUtil.setDataExpire("RT:" + user.getEmail(), refreshToken, REFRESH_TOKEN_VALIDITY);
+
+                return new AuthResponse(user, accessToken, refreshToken, oauthAccessToken);
             }
             case NAVER -> {
                 var naverProfile = naverUtil.requestProfileByAccessToken(oauthAccessToken);
@@ -61,7 +75,6 @@ public class AuthService {
                 .map(existingUser -> {
                     existingUser.updateNickname(profile.getNickname());
                     existingUser.updateEmail(profile.getEmail());
-//                    existingUser.updateProfileUrl(profile.getProfileImageUrl());
                     return existingUser;
                 })
                 .orElseGet(() -> createNewUser(profile));
@@ -71,6 +84,18 @@ public class AuthService {
         redisUtil.setDataExpire("RT:" + user.getEmail(), refreshToken, REFRESH_TOKEN_VALIDITY);
 
         return new AuthResponse(user, accessToken, refreshToken, oauthAccessToken);
+    }
+
+    private User createNewUserWithProviderId(OAuthProfile profile, String kakaoId) {
+        return userRepository.save(
+                User.builder()
+                        .providerInfo(profile.getProviderInfo())
+                        .providerId(kakaoId)
+                        .email(profile.getEmail())
+                        .nickname(profile.getNickname())
+                        .role(RoleType.USER)
+                        .build()
+        );
     }
 
     private User createNewUser(OAuthProfile profile) {

--- a/src/main/java/com/ddd/oi/user/domain/User.java
+++ b/src/main/java/com/ddd/oi/user/domain/User.java
@@ -26,6 +26,9 @@ public class User extends BaseEntity {
 	@Column(name = "provider_info", nullable = false)
 	private ProviderInfo providerInfo;
 
+	@Column(name = "provider_id")
+	private String providerId;
+
 	@Column(name = "nickname")
 	private String nickname;
 

--- a/src/main/java/com/ddd/oi/user/repository/UserRepository.java
+++ b/src/main/java/com/ddd/oi/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.ddd.oi.user.repository;
 
+import com.ddd.oi.user.domain.ProviderInfo;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,6 +10,6 @@ import com.ddd.oi.user.domain.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByNickname(String nickname);
+    Optional<User> findByProviderInfoAndProviderId(ProviderInfo provider, String providerId);
     Optional<User> findByEmail(String email);
 }


### PR DESCRIPTION
## 1. [수정 제목 또는 간단 설명]
- 🚨 문제점
    - 카카오계정 이외의 이메일은 로그인 안됨

- 🔍 원인 분석
    - email식별대신 카카오만 providerInfo+providerId로 식별하도록 수정

- 💡 해결 방법
    - 적용한 해결 방안 설명

- 🔄 수정 전/후 비교
  |수정 전|수정 후|
  |:-:|:-:|
  |<video src="" />|<video src="" />|
